### PR TITLE
feat: add message_tts parameter + fix parse_mode for notify channels

### DIFF
--- a/custom_components/universal_notifier/__init__.py
+++ b/custom_components/universal_notifier/__init__.py
@@ -20,7 +20,7 @@ from .const import (
     CONF_CHANNELS, CONF_ASSISTANT_NAME, CONF_DATE_FORMAT,
     CONF_GREETINGS, CONF_TIME_SLOTS, CONF_DND, CONF_BOLD_PREFIX,
     # Service keys (Inputs)
-    CONF_MESSAGE, CONF_TITLE, CONF_TARGETS, CONF_DATA, CONF_TARGET_DATA,
+    CONF_MESSAGE, CONF_MESSAGE_TTS, CONF_TITLE, CONF_TARGETS, CONF_DATA, CONF_TARGET_DATA,
     CONF_PRIORITY, CONF_SKIP_GREETING, CONF_INCLUDE_TIME, CONF_PRIORITY_VOLUME, CONF_OVERRIDE_GREETINGS,
     CONF_PERSON_ENTITIES,
     # Inner Channel keys
@@ -123,6 +123,7 @@ async def _apply_resume(hass: HomeAssistant, entity_id: str, target_volume: floa
 SEND_SERVICE_SCHEMA = vol.Schema({
     vol.Required(CONF_MESSAGE): cv.string,
     vol.Required(CONF_TARGETS): vol.All(cv.ensure_list, [cv.string]),
+    vol.Optional(CONF_MESSAGE_TTS): cv.string,
     vol.Optional(CONF_TITLE): cv.string,
     vol.Optional(CONF_DATA): dict,
     vol.Optional(CONF_TARGET_DATA): dict,
@@ -223,6 +224,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Handler principale del servizio 'send'."""
         # 1. Parsing Input
         global_raw_message = call.data.get(CONF_MESSAGE, "")
+        global_raw_tts_message = call.data.get(CONF_MESSAGE_TTS)  # None se non fornito
         global_title = call.data.get(CONF_TITLE)
         runtime_data = call.data.get(CONF_DATA, {})
         target_specific_data = call.data.get(CONF_TARGET_DATA, {})
@@ -280,6 +282,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 specific_data = target_specific_data[target_alias].copy()
             _LOGGER.debug(f"UniNotifier: Specific Data {specific_data}")
             target_raw_message = specific_data.pop(CONF_MESSAGE, global_raw_message)
+            target_raw_tts_message = specific_data.pop(CONF_MESSAGE_TTS, global_raw_tts_message)
 
             dynamic_entities = specific_data.pop(CONF_ENTITY_ID, channel_conf.get(CONF_TARGET))
             if isinstance(dynamic_entities, str):
@@ -328,7 +331,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 final_msg = target_raw_message
             else:
                 if is_voice_channel:
-                    clean_msg = clean_text_for_tts(str(target_raw_message))
+                    tts_source = target_raw_tts_message if target_raw_tts_message is not None else target_raw_message
+                    clean_msg = clean_text_for_tts(str(tts_source))
                     clean_greet = clean_text_for_tts(current_greeting)
                     full_spoken_text = ""
                     if final_title:

--- a/custom_components/universal_notifier/__init__.py
+++ b/custom_components/universal_notifier/__init__.py
@@ -447,6 +447,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 else:
                     service_payload.update(all_additional_data)
 
+            # Passa parse_mode ai canali notify non-voce così Telegram usa
+            # lo stesso formato (HTML/MarkdownV2) con cui è stato costruito il testo.
+            if not is_voice_channel and not is_command_message and srv_domain == "notify" and parse_mode:
+                if "data" not in service_payload:
+                    service_payload["data"] = {}
+                service_payload["data"].setdefault("parse_mode", parse_mode)
+
             ####################################################################
             physical_players = []
             # J. DISPATCH LOGIC: CODA PER VOCE vs IMMEDIATO

--- a/custom_components/universal_notifier/const.py
+++ b/custom_components/universal_notifier/const.py
@@ -14,6 +14,7 @@ CONF_PERSON_ENTITIES = "person_entities"
 
 # --- Chiavi Parametri Servizio (Service Call) ---
 CONF_MESSAGE = "message"
+CONF_MESSAGE_TTS = "message_tts"
 CONF_TITLE = "title"
 CONF_TARGETS = "targets"
 CONF_DATA = "data"


### PR DESCRIPTION
## Summary

This PR adds two improvements identified while testing migration from the AppDaemon Package-Notification-HUB.

### 1. New `message_tts` parameter

Adds an optional `message_tts` field to the `send` service. When provided, **voice channels** (Google Home, Alexa) use this text instead of `message`, while **text channels** (Telegram, Mobile App) continue to use `message`.

This allows sending emoji/markdown-rich text to Telegram and clean, readable speech to speakers from a single service call — a common pattern in the AppDaemon Notifier ecosystem.

**Example:**
```yaml
action: universal_notifier.send
data:
  message: "✅ R2D2 ha finito le pulizie! Batteria: 85% 🤖"
  message_tts: "R2D2 ha terminato le pulizie. Batteria all ottantacinque percento."
  targets:
    - telegram_user   # receives the emoji-rich text
    - google_home     # speaks the clean TTS text
```

Also supported per-target via `target_data[alias][message_tts]`. Falls back to `message` if not provided.

### 2. Fix: pass `parse_mode` to notify services

The `parse_mode` used to format the message (HTML or MarkdownV2) was being stripped before the `notify.*` service call. This caused Telegram to **silently reject messages** when the bot's default parse_mode (e.g. `markdownv2`) did not match the tags in the formatted text (e.g. `<b>` HTML tags from `bold_prefix`).

`parse_mode` is now injected into `service_payload["data"]` for non-voice `notify` channels so Telegram renders formatting correctly.

## Testing

Tested on a live Home Assistant instance with:
- `notify.telegrammarco` channel (telegram_bot configured with `parse_mode: markdownv2`)
- HTML bold prefix enabled
- Both `message` and `message_tts` fields

Before fix: messages silently dropped by Telegram due to parse_mode mismatch. After fix: messages received correctly with formatting rendered.