### PR TITLE
Add skip_assistant_name option to the send service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+- **Skip Assistant Name flag**: New optional `skip_assistant_name` boolean in the `universal_notifier.send` service. When true, the assistant name is omitted from the visual prefix (`[Home Assistant - 10:00]` becomes `[10:00]`). Combined with `include_time: false` and `skip_greeting: true`, notifications are delivered as the raw message with no prefix at all. Also fixes the stray `[ - 10:00]` prefix shown when the configured assistant name was empty.
+
 ## [0.8.3] - 2026-06-17 - PRODUCTION
 New version, see preproduction releases for new features
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ After initial setup, go to **Settings > Devices & Services > Universal Notifier 
 |target_data|dict|No|Dictionary {target_alias: {specific_data}} for targeted overrides.|
 |priority|bool|No|If true, bypasses DND and sets high volume (default 0.9).|
 |skip_greeting|bool|No|If true, does not add the time-based greeting (e.g., Good Morning).|
+|skip_assistant_name|bool|No|If true, omits the assistant name from the visual prefix.|
 |include_time|bool|No|Overrides the configuration to include/exclude the time in the visual prefix.|
 |ignore_title_voice|bool|No|If true, ignores the title for voice notifications (TTS/notify voice channels).|
 |bold_prefix|bool|No|Overrides the configuration to have assistant name and time in bold|

--- a/README_IT.md
+++ b/README_IT.md
@@ -168,6 +168,7 @@ Dopo la configurazione iniziale, vai in **Impostazioni > Dispositivi e servizi >
 |target_data|dict|No|Dizionario {alias_target: {dati_specifici}} per override mirati.|
 |priority|bool|No|Se true, ignora il DND e imposta volume alto (default 0.9).|
 |skip_greeting|bool|No|Se true, non aggiunge il saluto basato sull'ora (es. Buongiorno).|
+|skip_assistant_name|bool|No|Se true, omette il nome dell'assistente dal prefisso visivo.|
 |include_time|bool|No|Sovrascrive la configurazione per includere/escludere l'ora nel prefisso visivo.|
 |ignore_title_voice|bool|No|Se true, ignora il titolo per le notifiche vocali (TTS/canali voice).|
 |bold_prefix|bool|No|Sovrascrive la configurazione per mettere in grassetto nome assistente e ora.|

--- a/custom_components/universal_notifier/__init__.py
+++ b/custom_components/universal_notifier/__init__.py
@@ -21,7 +21,8 @@ from .const import (  # Config keys; Service keys (Inputs); Inner Channel keys; 
     CONF_DEFAULT_MEDIA_PLAYER, CONF_DND, CONF_ENTITY_ID, CONF_GREETINGS,
     CONF_IGNORE_TITLE_VOICE, CONF_INCLUDE_TIME, CONF_IS_VOICE, CONF_MESSAGE,
     CONF_OVERRIDE_GREETINGS, CONF_PERSON_ENTITIES, CONF_PRIORITY,
-    CONF_PRIORITY_VOLUME, CONF_SERVICE, CONF_SKIP_GREETING, CONF_TARGET,
+    CONF_PRIORITY_VOLUME, CONF_SERVICE, CONF_SKIP_ASSISTANT_NAME,
+    CONF_SKIP_GREETING, CONF_TARGET,
     CONF_TARGET_DATA, CONF_TARGETS, CONF_TIME_SLOTS, CONF_TITLE, CONF_TYPE,
     DOMAIN, ENTITY_DND_OVERRIDE, ENTITY_LAST_MESSAGE, PLATFORMS)
 ####
@@ -119,6 +120,7 @@ SEND_SERVICE_SCHEMA = vol.Schema({
     vol.Optional(CONF_TARGET_DATA): dict,
     vol.Optional(CONF_PRIORITY): cv.boolean,
     vol.Optional(CONF_SKIP_GREETING): cv.boolean,
+    vol.Optional(CONF_SKIP_ASSISTANT_NAME): cv.boolean,
     vol.Optional(CONF_INCLUDE_TIME): cv.boolean,
     vol.Optional(CONF_PRIORITY_VOLUME): cv.string,
     vol.Optional(CONF_ASSISTANT_NAME): cv.string,
@@ -226,6 +228,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         targets = call.data.get(CONF_TARGETS, [])
         override_name = call.data.get(CONF_ASSISTANT_NAME, global_name)
         skip_greeting = call.data.get(CONF_SKIP_GREETING, False)
+        skip_assistant_name = call.data.get(CONF_SKIP_ASSISTANT_NAME, False)
         include_time = call.data.get(CONF_INCLUDE_TIME, global_include_time)
         # priority_volume: prima controlla override runtime (select entity), poi call data, poi config
         runtime_pv = hass.data[DOMAIN][entry.entry_id].get("runtime_priority_vol")
@@ -365,16 +368,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                         clean_name = apply_formatting(clean_name, parse_mode, "bold")
                         clean_time = apply_formatting(clean_time, parse_mode, "bold")
                         clean_orig_title = apply_formatting(clean_orig_title, parse_mode, "bold")
-                    prefix_content = clean_name
+                    prefix_parts = []
+                    if clean_name and not skip_assistant_name:
+                        prefix_parts.append(clean_name)
                     if clean_time:
-                        prefix_content += f" - {clean_time}"
-                    clean_prefix = f"[{prefix_content}]"
+                        prefix_parts.append(clean_time)
+                    clean_prefix = f"[{' - '.join(prefix_parts)}]" if prefix_parts else ""
                     greeting_part = f"{clean_greet}. " if clean_greet else ""
                     if clean_orig_title:
-                        final_title = f"{clean_prefix} {clean_orig_title}"
+                        final_title = f"{clean_prefix} {clean_orig_title}" if clean_prefix else clean_orig_title
                         final_msg = f"{greeting_part}{clean_msg}"
                     else:
-                        final_msg = f"{clean_prefix} {greeting_part}{clean_msg}"
+                        final_msg = f"{clean_prefix} {greeting_part}{clean_msg}" if clean_prefix else f"{greeting_part}{clean_msg}"
 
             # Escape MarkdownV2 special chars for Telegram
             if not is_voice_channel and parse_mode == "markdownv2":

--- a/custom_components/universal_notifier/const.py
+++ b/custom_components/universal_notifier/const.py
@@ -21,6 +21,7 @@ CONF_DATA = "data"
 CONF_TARGET_DATA = "target_data"
 CONF_PRIORITY = "priority"
 CONF_SKIP_GREETING = "skip_greeting"
+CONF_SKIP_ASSISTANT_NAME = "skip_assistant_name"
 CONF_OVERRIDE_GREETINGS = "override_greetings"
 
 # --- Entity IDs (auto-created by integration) ---

--- a/custom_components/universal_notifier/services.yaml
+++ b/custom_components/universal_notifier/services.yaml
@@ -96,6 +96,13 @@ send:
       selector:
         boolean:
 
+    skip_assistant_name:
+      name: Skip Assistant Name
+      description: If active, omits the assistant name from the visual prefix (e.g., "[Home Assistant - 10:00]" becomes "[10:00]", or no prefix if time is also disabled).
+      required: false
+      selector:
+        boolean:
+
     include_time:
       name: Include Time
       description: If disabled, omits the time in the visual prefix.

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -269,6 +269,52 @@ class TestTitleAndPrefix:
             prefix_part = msg.split("]")[0]
             assert ":" not in prefix_part
 
+    @freeze_time("2026-06-17 10:00:00")
+    async def test_skip_assistant_name(
+        self, hass, _call_send, service_calls
+    ):
+        """skip_assistant_name=True should omit the name but keep the time prefix."""
+        await _call_send(
+            message="Body",
+            targets=["test_text"],
+            skip_assistant_name=True,
+        )
+        msg = service_calls[0]["data"].get("message", "")
+        assert "Assistant" not in msg  # configured name
+        assert msg.startswith("[")  # time-only prefix remains
+        assert ":" in msg.split("]")[0]
+
+    @freeze_time("2026-06-17 10:00:00")
+    async def test_skip_assistant_name_no_time_no_greeting(
+        self, hass, _call_send, service_calls
+    ):
+        """With name, time and greeting all skipped, message is just the raw body."""
+        await _call_send(
+            message="Body",
+            targets=["test_text"],
+            skip_assistant_name=True,
+            include_time=False,
+            skip_greeting=True,
+        )
+        msg = service_calls[0]["data"].get("message", "")
+        assert msg == "Body"
+
+    @freeze_time("2026-06-17 10:00:00")
+    async def test_skip_assistant_name_with_title(
+        self, hass, _call_send, service_calls
+    ):
+        """skip_assistant_name=True should omit the name from the title prefix too."""
+        await _call_send(
+            message="Body",
+            title="My Title",
+            targets=["test_text"],
+            skip_assistant_name=True,
+        )
+        data = service_calls[0]["data"]
+        title = data.get("title", "")
+        assert "Assistant" not in title
+        assert "My Title" in title
+
 
 # ============================================================================
 # Telegram routing


### PR DESCRIPTION
## Description

Adds an optional `skip_assistant_name` boolean to the `universal_notifier.send` service. When true, the assistant name is omitted from the visual prefix:

| Flags | Result |
|---|---|
| none (default) | `[Assistant - 10:00] Greeting. Message` (unchanged) |
| `skip_assistant_name: true` | `[10:00] Greeting. Message` |
| + `include_time: false` + `skip_greeting: true` | `Message` |

When the prefix is empty, no brackets or leading space are emitted — this also fixes the `[ - 10:00]` artifact when the configured assistant name is empty. Voice/TTS and `command_*` messages are unaffected.

Changes: new constant in `const.py`, schema + handler + prefix logic in `__init__.py`, new field in `services.yaml`, 3 new tests, service field tables in `README.md`/`README_IT.md`, and a `CHANGELOG.md` entry.

## Motivation and Context

There is no way to send a notification without the `[Assistant Name]` prefix — the name can be overridden but never removed, so mobile notifications always arrive as e.g. `[Home Assistant] Good Morning. Your house is flooding`. This adds the missing flag, matching the existing `skip_greeting` / `include_time` options.

## How has this been tested?

- 3 new tests in `tests/test_init.py` covering: name removed with time kept, fully bare message (all flags), and name removed from the title prefix
- Full suite via the project's Docker `test-runner`: **126 passed**, existing prefix/greeting/title tests unchanged
- Manual tests overriding the files in a Home Assistant instance to test the UI configuration and notification sent (tested on an Android companion app)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (did my best in Italian readme)
