### PR TITLE
fix: preserve SSML tags in clean_text_for_tts

### DIFF
--- a/custom_components/universal_notifier/utils.py
+++ b/custom_components/universal_notifier/utils.py
@@ -94,10 +94,23 @@ def get_current_slot_info(slots_conf: dict, now_time,
             current_vol = vol_val
     return current_slot, current_vol
 
+# Tag SSML supportati dai motori TTS (Alexa, Google): vanno preservati.
+SSML_TAGS = {
+    "speak", "voice", "prosody", "break", "say-as", "emphasis",
+    "lang", "phoneme",
+}
+_TAG_PATTERN = re.compile(r'<\s*/?\s*([a-zA-Z][\w:-]*)[^>]*>')
+
+def _strip_non_ssml_tags(text: str) -> str:
+    """Rimuove i tag HTML mantenendo i tag SSML noti."""
+    return _TAG_PATTERN.sub(
+        lambda m: m.group(0) if m.group(1).lower() in SSML_TAGS else '', text
+    )
+
 def clean_text_for_tts(text: str) -> str:
     """Rimuove caratteri speciali per la sintesi vocale."""
     if not text: return ""
-    text = re.sub(r'<[^>]+>', '', text)    # Via HTML tags
+    text = _strip_non_ssml_tags(text)      # Via HTML tags, tiene SSML
     text = re.sub(r'[*_`\[\]]', '', text) # Via markdown
     text = re.sub(r'http\S+', '', text)    # Via URL
     # Via emoji/icon (preserva lettere accentate latin-1)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -201,6 +201,21 @@ class TestCleanTextForTTS:
     def test_collapses_whitespace(self):
         assert clean_text_for_tts("hello   world") == "hello world"
 
+    def test_preserves_ssml_voice_tag(self):
+        assert clean_text_for_tts(
+            "<voice name='Giorgio'>Il sistema è operativo!</voice>"
+        ) == "<voice name='Giorgio'>Il sistema è operativo!</voice>"
+
+    @pytest.mark.parametrize("tag", ["prosody rate='slow'", "break time='500ms'",
+                                     "say-as interpret-as='date'", "emphasis"])
+    def test_preserves_other_ssml_tags(self, tag):
+        assert f"<{tag}>" in clean_text_for_tts(f"<{tag}>ciao")
+
+    def test_strips_html_around_ssml(self):
+        assert clean_text_for_tts(
+            "<b><voice name='Giorgio'>ciao</voice></b>"
+        ) == "<voice name='Giorgio'>ciao</voice>"
+
 
 # ============================================================================
 # sanitize_text_visual


### PR DESCRIPTION
## Description

`clean_text_for_tts()` removed every angle-bracket tag with `re.sub(r'<[^>]+>', '', text)`, which also stripped valid SSML markup such as `<voice name="Giorgio">`. Tag removal is now name-aware: known SSML tags (`speak`, `voice`, `prosody`, `break`, `say-as`, `emphasis`, `lang`, `phoneme`) are preserved, every other tag is stripped exactly as before.

## Motivation and Context

Closes #32 — SSML voice tags never reached the TTS service, so Alexa always used its default voice.

## How has this been tested?

Added `test_preserves_ssml_voice_tag`, a parametrized `test_preserves_other_ssml_tags`, and `test_strips_html_around_ssml` to `tests/test_utils.py`. They fail on the current code (6 failures) and pass with the fix; the whole `tests/test_utils.py` suite is green (67 passed).

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
